### PR TITLE
usb_gadget: fix MTP

### DIFF
--- a/drivers/usb/gadget/android.c
+++ b/drivers/usb/gadget/android.c
@@ -49,7 +49,7 @@
 #include "u_serial.c"
 #include "f_acm.c"
 #include "f_adb.c"
-#include "f_mtp_samsung.c"
+#include "f_mtp.c"
 #include "f_accessory.c"
 
 #define USB_ETH_RNDIS y


### PR DESCRIPTION
MTP is broken in CM11
This patch fixes it by using generic f_mtp.c instead of Samsung ones.

CC: @corphish
